### PR TITLE
>> Quick fix in descriptions in /main/Settings/strings.xml

### DIFF
--- a/Italian/main/Settings.apk/res/values-it/strings.xml
+++ b/Italian/main/Settings.apk/res/values-it/strings.xml
@@ -2804,10 +2804,10 @@ Disabilitare le finestre flottanti?"</string>
     <string name="toast_need_login">Accedi al tuo Account Mi</string>
     <string name="location_access_on">Attivato</string>
     <string name="location_access_off">Disattivato</string>
-    <string name="preferred_app_settings">Impostazioni predefinite</string>
-    <string name="preferred_app_settings_default">Predefinite</string>
+    <string name="preferred_app_settings">App predefinite</string>
+    <string name="preferred_app_settings_default">Predefinita</string>
     <string name="preferred_app_settings_reset">Ripristino predefinite</string>
-    <string name="preferred_app_settings_reset_message">Ripristinare impostazioni App predefinite?</string>
+    <string name="preferred_app_settings_reset_message">Ripristinare app predefinite?</string>
     <string name="preferred_app_settings_reset_button">Ripristina</string>
     <string name="system_app_settings">Applicazioni di sistema</string>
     <string name="connect_to_internet">Rete Wi-Fi</string>


### PR DESCRIPTION
La descrizione App predefinite come in altri telefoni sembra più chiara rispetto a Impostazioni predefinite che in questo menu non si capisce che funzione abbia. (Praticamente è il menu per scegliere l'app preferita e predefinita...)
O poi cambiato predefinite al plurale(in inglese c'è default al singolare e non defaults che in quella lingua e in quel menu è il corrispondente di "Impostazioni predefinite"). A voi

Allego screenshot

![screenshot_2015-12-04-01-31-55_com android settings](https://cloud.githubusercontent.com/assets/16099943/11579092/60168714-9a2b-11e5-9ce3-7a76f622a98e.png)
![screenshot_2015-12-04-01-26-50_com android settings](https://cloud.githubusercontent.com/assets/16099943/11579093/60386d7a-9a2b-11e5-9702-6e5e5a53c2da.png)
