### PR TITLE
[Proposed modification] Changed Lista blocchi/blocco with Blacklist i…

### DIFF
--- a/Italian/main/SecurityCenter.apk/res/values-it/strings.xml
+++ b/Italian/main/SecurityCenter.apk/res/values-it/strings.xml
@@ -251,7 +251,7 @@
     <string name="menu_text_networkassistants">Utilizzo dati</string>
     <string name="menu_text_networkassistants_remain">%s rimasti</string>
     <string name="menu_text_networkassistants_danger">%s fuori soglia</string>
-    <string name="menu_text_antispam">Lista blocchi</string>
+    <string name="menu_text_antispam">Blacklist</string>
     <string name="menu_text_license_manager">Permessi</string>
     <string name="menu_text_garbage_cleanup">Pulizia</string>
     <string name="menu_text_power_manager">Gestione alimentazione</string>
@@ -290,7 +290,7 @@
     <string name="activity_title_settings">Impostazioni</string>
     <string name="activity_title_antivirus">Antivirus</string>
     <string name="activity_title_networkassistants">Utilizzo dati</string>
-    <string name="activity_title_antispam">Lista blocchi</string>
+    <string name="activity_title_antispam">Blacklist</string>
     <string name="activity_title_license_manager">Permessi</string>
     <string name="activity_title_power_manager">Batteria</string>
     <string name="activity_title_garbage_cleanup">Pulizia</string>


### PR DESCRIPTION
…n Security center

"Lista blocchi" suona male, propongo questa modifica con Blacklist. In altri telefoni è presente questa dicitura, anche in Windows phone se non ricordo male e blacklist è una parola in uso nell'italiano corrente (come File explorer alla fine). I francesi hanno messo liste noir, ma lista nera mi sembra tanto da ventennio. Comunque, in alcune righe c'è Lista blocco, in altre Lista blocchi e in altre Lista Blocco.

Se non d'accordo approvate almeno la PR #271
A voi.