### PR TITLE
[Proposed modification] Changed Lista blocchi/blocco with Blacklist i…

### DIFF
--- a/Italian/main/Contacts.apk/res/values-it/strings.xml
+++ b/Italian/main/Contacts.apk/res/values-it/strings.xml
@@ -1114,7 +1114,7 @@ Tocca l'icona Unisci in basso per iniziare."</string>
     <string name="yellowpage_navigation_more_items_title">Altri servizi</string>
     <string name="imei_invalid">IMEI non valido</string>
     <string name="meid_invalid">MEID non valido</string>
-    <string name="firewall_setting">Lista blocchi</string>
+    <string name="firewall_setting">Blacklist</string>
     <string name="solar_calendar">Solare</string>
     <string name="lunar_calendar">Lunare</string>
     <string name="lunar_leap" />


### PR DESCRIPTION
…n contacts

"Lista blocchi" suona male, propongo questa modifica con Blacklist. In altri telefoni è presente questa dicitura, anche in Windows phone se non ricordo male e blacklist è una parola in uso nell'italiano corrente (come File explorer alla fine). I francesi hanno messo liste noir, ma lista nera mi sembra tanto da ventennio. Comunque, in alcune righe c'è Lista blocco, in altre Lista blocchi e in altre Lista Blocco.

Se non d'accordo approvate almeno la PR #271 
 A voi.