### PR TITLE
>>  Fix bad description in leo/Settings.apk/res/values-it/plurals.xml

### DIFF
--- a/Italian/device/leo/Settings.apk/res/values-it/plurals.xml
+++ b/Italian/device/leo/Settings.apk/res/values-it/plurals.xml
@@ -41,8 +41,8 @@
         <item quantity="one">"Codice PIN errato. Hai ancora %d tentativo a disposizione, dopodiché dovrai contattare l'operatore per sbloccare il dispositivo."</item>
     </plurals>
     <plurals name="manage_notification_access_summary_nonzero">
-        <item quantity="other">Le app %d possono leggere le notifiche</item>
-        <item quantity="one">"L'app %d può leggere le notifiche"</item>
+        <item quantity="other">%d app possono leggere le notifiche</item>
+        <item quantity="one">%d app può leggere le notifiche</item>
     </plurals>
     <plurals name="manage_condition_providers_summary_nonzero">
         <item quantity="other">%d app forniscono condizioni</item>


### PR DESCRIPTION
![screenshot_2015-12-07-23-46-33_com android settings](https://cloud.githubusercontent.com/assets/16099943/11643899/49a633ca-9d47-11e5-9b2c-4393c46153d6.png)