### PR TITLE
Update cancro/settings.xml (notifications )

### DIFF
--- a/Italian/device/cancro/Settings.apk/res/values-it/strings.xml
+++ b/Italian/device/cancro/Settings.apk/res/values-it/strings.xml
@@ -57,12 +57,15 @@
     <string name="status_bar_and_notification_bar">Barra notifiche e barra di stato</string>
     <string name="status_bar_settings_manage_notification">Gestisci notifiche</string>
     <string name="status_bar_settings_all_app_display_loading">Caricamento…</string>
+    <string name="status_bar_app_enable_message">Badge</string>
+    <string name="status_bar_app_enable_floating">Notifiche a comparsa</string>
+    <string name="status_bar_app_enable_keyguard">Lockscreen</string>
     <string name="status_bar_settings_enable_notification">Consenti notifiche</string>
     <string name="status_bar_settings_notification_priority">Priorità</string>
     <string name="status_bar_settings_notification_priority_summary">Mostra le notifiche in cima alla lista</string>
     <string name="status_bar_settings_show_home_message">Badge icona app</string>
-	<string name="status_bar_settings_show_floating_notification">Finestre di notifica</string>
-    <string name="status_bar_settings_show_floating_notification_summary">Le finestre di notifica scompariranno automaticamente dopo essere comparse in alto</string>
+    <string name="status_bar_settings_show_floating_notification">Notifiche a comparsa</string>
+    <string name="status_bar_settings_show_floating_notification_summary">Le notifiche scompariranno automaticamente dopo essere apparse in alto sullo schermo</string>
     <string name="status_bar_settings_show_keyguard_notification">Notifiche sulla lockscreen</string>
     <string name="status_bar_settings_show_keyguard_notification_summary" />
     <string name="status_bar_settings_notification_sound_vibrate">Suoni e vibrazione</string>


### PR DESCRIPTION
Uniformato con gli altri device e settings.xml che appunto riporta la dicitura Notifiche a comparsa.
Per mocha è già stato fatto nella #300 
Per Libra, Ferrari, Leo e Hermes nella traduzione completa in #323 #325 #326 #327 

Aggiunte 
     
      <string name="status_bar_app_enable_message">Badge</string>
      <string name="status_bar_app_enable_floating">Notifiche a comparsa</string>
      <string name="status_bar_app_enable_keyguard">Lockscreen</string>

per fixare problema riportato nella https://github.com/MishFdM/MIUI_V7_Italy/issues/295

e modificate  64 e 65 

<string name="status_bar_settings_show_floating_notification">Notifiche a comparsa</string>
<string name="status_bar_settings_show_floating_notification_summary">Le notifiche scompariranno automaticamente dopo essere apparse in alto sullo schermo</string>

A voi

