### PR TITLE
>> Added video call menu strings main/settings.xml

### DIFF
--- a/Italian/main/InCallUI.apk/res/values-it/strings.xml
+++ b/Italian/main/InCallUI.apk/res/values-it/strings.xml
@@ -55,12 +55,17 @@
     <string name="onscreen_audio_mode_handset">Kit mani libere</string>
     <string name="onscreen_audio_mode_headset">Cuffie</string>
     <string name="onscreen_audio_mode_speaker">Vivavoce</string>
-    <string name="onscreen_audio_switch_mode">Scambia audio</string>
+    <string name="onscreen_audio_switch_mode">Cambia audio</string>
+    <string name="onscreen_change_to_video">Videochiamata</string>
+    <string name="onscreen_change_to_voice">Chiamata</string>
     <string name="onscreen_call_record">Registra</string>
-    <string name="onscreen_hold_text">Trattieni</string>
+    <string name="onscreen_hold_text">In attesa</string>
     <string name="onscreen_merge_calls_text">Unisci chiamate</string>
     <string name="onscreen_mute_text">Muto</string>
-    <string name="onscreen_swap_calls_text">Scambia</string>
+    <string name="onscreen_swap_calls_text">Cambia</string>
+    <string name="onscreen_close_preview_camera">Chiudi fotocamera</string>
+    <string name="onscreen_switch_camera">Cambia fotocamera</string>
+    <string name="onscreen_rcs_text">Messaggi</string>
     <string name="call_record_button_label">Registrazione %s</string>
     <string name="call_record_wait_label">In attesa</string>
     <string name="contacts_icon_label">Contatti</string>
@@ -70,12 +75,12 @@
     <string name="callUnanswered_forwarded">Chiamata senza risposta ed inoltrata</string>
     <string name="caller_manage_header">Audioconferenza %s</string>
     <string name="incall_call_type_label_sip">Chiamata Internet</string>
-    <string name="incoming_call_forwarded_title">Inoltro chiamate in arrivo</string>
+    <string name="incoming_call_forwarded_title">Inoltro chiamate ricevute</string>
     <string name="call_title_redialing_with_times">Ricomposto %d volte</string>
     <string name="card_title_dialing">Chiamata in corso</string>
     <string name="card_title_conf_call">Audioconferenza</string>
     <string name="card_title_threeway_call">Audioconferenza a tre</string>
-    <string name="card_title_incoming_call">Chiamate in arrivo</string>
+    <string name="card_title_incoming_call">Chiamata ricevuta</string>
     <string name="card_title_call_ended">Chiamata terminata\u0020</string>
     <string name="card_title_on_hold">In attesa\u0020</string>
     <string name="card_title_hanging_up">In fase di chiusura\u0020</string>
@@ -92,12 +97,21 @@
     <string name="notification_ongoing_call">Chiamata in corso</string>
     <string name="notification_on_hold">In attesa</string>
     <string name="notification_incoming_call">Chiamata ricevuta</string>
+    <string name="notification_incoming_video_call">Videochiamata ricevuta</string>
+    <string name="card_title_upgrade_video_call_error">Impossibile aggiornare il video</string>
+    <string name="card_title_upgrade_video_call_rejected_by_remote">Impossibile aggiornare il video</string>
+    <string name="card_title_upgrade_video_call_requesting">Richiesta video in corso</string>
+    <string name="card_title_upgrade_video_call_timed_out">Impossibile aggiornare il video</string>
+    <string name="card_title_video_call">Videochiamata</string>
+    <string name="card_title_video_call_paused">Videochiamata in attesa</string>
     <string name="notification_action_accept">Accetta</string>
     <string name="notification_action_answer_video">Video</string>
     <string name="notification_action_answer_voice">Voce</string>
     <string name="notification_action_dismiss">Rifiuta</string>
     <string name="notification_action_end_call">Termina</string>
-    <string name="notification_requesting_video_call">Richiesta video in arrivo</string>
+    <string name="notification_requesting_video_call">Richiesta video ricevuta</string>
+    <string name="video_call_not_allowed_if_tty_enabled">Disattiva prima la modalità TTY</string>
+    <string name="video_switch_to_voice_call_prompt">Trasforma in chiamata vocale</string>
     <string name="add_vm_number_str">Aggiungi numero</string>
     <string name="no_vm_number">Numero segreteria mancante</string>
     <string name="no_vm_number_msg">Nessun numero di segreteria presente nella SIM.</string>
@@ -164,7 +178,7 @@
     <string name="jeejen_answer_call_text">Rispondi</string>
     <string name="jeejen_reject_call_text">Rifiuta</string>
     <string name="jeejen_end_call_text">Chiudi</string>
-    <string name="jeejen_toggle_dialpad_text">Tastiera</string>
+    <string name="jeejen_toggle_dialpad_text">Tastierino</string>
     <string name="miprofile_stranger_card">Scheda straniera</string>
     <string name="no_balance_title">Credito insufficiente</string>
     <string name="no_balance_message">Credito insufficiente nel pacchetto di ricarica. Puoi provare con una chiamata normale.</string>
@@ -176,4 +190,5 @@
     <string name="dial_with_gsm_phone">Chiamata normale</string>
     <string name="purchase_now">Ricarica</string>
     <string name="cancel_call">Termina</string>
+    
 </resources>


### PR DESCRIPTION
Dalla versione 5.12.4 è apparsa nel menu in chiamata la voce "Video Call" e la voce "Messages".

Aggiunte le stringhe della funzione di video chiamata. 
Tastierino invece di tastiera come per le altre stringhe.
Chiamata ricevuta rigo 78, che si usa per le incoming call in Android lollipop, è al singolare (call) .
Altre ottimizzazioni..


![2014-11-25](https://cloud.githubusercontent.com/assets/16099943/11744431/a3e69e44-a010-11e5-8432-ec6579853058.jpg)


