### PR TITLE
Correct descriptions in NetworkAssistant2.apk

### DIFF
--- a/Italian/main/NetworkAssistant2.apk/res/values-it/strings.xml
+++ b/Italian/main/NetworkAssistant2.apk/res/values-it/strings.xml
@@ -61,7 +61,7 @@ Fascia bassa: %1$s rimanenti | %2$s usati"</string>
     <string name="usage_sorted_activity_lable">Utilizzo dati</string>
     <string name="usage_sorted_loading_text">Caricamento…</string>
     <string name="usage_sorted_empty_text">Vuoto</string>
-    <string name="person_hotpot">Hotspot mobili</string>
+    <string name="person_hotpot">Hotspot mobile</string>
     <string name="system_app">Applicazioni di sistema</string>
     <string name="deleted_apps">Applicazioni eliminate</string>
     <string name="root">Root</string>
@@ -156,7 +156,7 @@ Fascia bassa: %1$s rimanenti | %2$s usati"</string>
     <string name="power_save_on_time_default_time">00:00</string>
     <string name="power_save_on_time_start_time_summary">Dalle</string>
     <string name="power_save_on_time_end_time_summary">Alle</string>
-    <string name="manual_input_traffic">Imposta utilizzo dati</string>
+    <string name="manual_input_traffic">Imposta limite di utilizzo dati</string>
     <string name="manual_input_free_traffic">Imposta utilizzo dati fuori soglia</string>
     <string name="declaration_dialog_msg">"Questa funzione può aiutarti a tenere sotto controllo l'utilizzo dei dati, ma non garantisce la prevenzione di costi aggiuntivi. Per un risultato migliore si consiglia di impostare un margine abbondante."</string>
     <string name="input_used_hint">Inserisci utilizzo dati</string>


### PR DESCRIPTION
#### Riga 64 ####
Quell'opzione è presente nei dettagli selezionando una rete wi-fi, permette di segnare la rete wifi appunto come "Hotspot mobile", in modo che ne venga limitato/controllato l'utilizzo dei dati http://www.androidcentral.com/how-tag-wifi-access-points-hotspots-your-android-device. 
In Android, in utilizzo dati nel Menu a tendina c'è "Hotspot mobili" che però è un menu: cliccando appare una lista di reti wifi e dei checkbox dove è possibile selezionare quali reti sono appunto Hotspot mobili (allego screenshot in basso). Voglio segnalare questa cosa anche a @ingbrzy per la traduzione del repo principale. 
Io penso la traduzione più giusta sia hotspot mobile. Allego screenshot. 

#### Riga 159 ####
dovrebbe essere "Imposta Limite di utilizzo dati" - in inglese "Set data usage limit" perché appunto ti fa impostare un limite (è cambiato il menu in cui ti porta quel bottone vedi screenshot), consiglio di cambiare almeno questa definizione se non siete d'accordo con quella di hotspot mobili :) A voi.

![screenshot_2015-12-12-13-24-14_com android settings](https://cloud.githubusercontent.com/assets/16099943/11762005/49421f82-a0d7-11e5-8cb6-39597e6e007a.png)

![screenshot_2013-01-29-14-34-18](https://cloud.githubusercontent.com/assets/16099943/11762079/e3b58ee8-a0da-11e5-8342-dd099520e09b.png)


![screenshot_2015-12-12-13-36-56_com miui networkassistant](https://cloud.githubusercontent.com/assets/16099943/11762008/6c3897aa-a0d7-11e5-9efa-08f6eec7626a.png)
