### PR TITLE
>> Quick fix old bad description in MiuiGallery.apk

### DIFF
--- a/Italian/main/MiuiGallery.apk/res/values-it/strings.xml
+++ b/Italian/main/MiuiGallery.apk/res/values-it/strings.xml
@@ -231,7 +231,9 @@
     <string name="rename_failed">Impossibile rinominare</string>
     <string name="rename_failed_duplicated_name">Esiste già un file con questo nome.</string>
     <string name="warn">Avviso</string>
-    <string name="send_multiple_files_hint_format">Invia file multipli (%s)</string>
+    <string name="send_multiple_files_hint_format">Invia file (%s)</string>
+    <string name="operation_add_secret_button">Nascondi</string>
+    <string name="operation_remove_secret_button">Rendi visibile</string>
     <string name="send">Invia</string>
     <string name="select_too_much_to_send_tips">Le foto selezionate sono troppo grandi per essere inviate. Il limite massimo è %d.</string>
     <string name="pick_too_much_tips">Non puoi selezionare tutti gli elementi (massimo %d)."</string>


### PR DESCRIPTION
Praticamente nel menu di invio nella galleria anche selezionando un solo file esce "invia file multipli".
Così è la scritta in inglese string name="send_multiple_files_hint_format">Send (%s)</string.

Non era tradotta "Hide" e "unhide"

![screenshot_2015-12-12-22-27-38_android](https://cloud.githubusercontent.com/assets/16099943/11764031/fbe7f366-a120-11e5-8a78-e8f2f8b54774.png)
