### PR TITLE
>> Quick fix description NetworkAssistant2.apk

### DIFF
--- a/Italian/main/NetworkAssistant2.apk/res/values-it/strings.xml
+++ b/Italian/main/NetworkAssistant2.apk/res/values-it/strings.xml
@@ -11,7 +11,7 @@
     <string name="main_toolbar_statistic">Statistiche</string>
     <string name="main_toolbar_saving">Risparmio</string>
     <string name="main_toolbar_purchase">Ricarica</string>
-    <string name="main_button_usage_adjust">Imposta utilizzo dati</string>
+    <string name="main_button_usage_adjust">Imposta limite di utilizzo dati</string>
     <string name="main_button_usage_adjusting">Modifica…</string>
     <string name="main_button_usage_adjust_manual">Imposta utilizzo dati</string>
     <string name="main_button_usage_package_setting">Imposta utilizzo dati</string>


### PR DESCRIPTION
#### Riga 159 ####
dovrebbe essere "Imposta Limite di utilizzo dati" - in inglese "Set data usage limit" perché appunto ti fa impostare un limite (è cambiato il menu in cui ti porta quel bottone vedi screenshot), consiglio di cambiare almeno questa definizione se non siete d'accordo con quella di hotspot mobili :) A voi.

![screenshot_2015-12-12-13-36-56_com miui networkassistant](https://cloud.githubusercontent.com/assets/16099943/11762008/6c3897aa-a0d7-11e5-9efa-08f6eec7626a.png)
