### PR TITLE
>> Translated and fixed Mobile Hotspot in hermes/settings.apk

### DIFF
--- a/Italian/device/hermes/Settings.apk/res/values-it/strings.xml
+++ b/Italian/device/hermes/Settings.apk/res/values-it/strings.xml
@@ -3285,7 +3285,7 @@ Disabilitare le finestre flottanti?"</string>
     <string name="wifi_available_title">Connetti al Wi-Fi</string>
     <string name="msg_wlan_signal_found">"E' disponibile punto d'accesso Wi-Fi %s, connettersi ora?"</string>
     <string name="wifi_signal_found_msg">"Un punto d'acceso Wi-Fi è disponibile, connettersi ora?"</string>
-    <string name="miui_data_usage_menu_metered">Mobile hotspots</string>
+    <string name="miui_data_usage_menu_metered">Hotspot mobile</string>
     <string name="wifi_click_share_wlan">Tocca per condividere la password</string>
     <string name="nfc_category_title">NFC</string>
     <string name="android_beam_tips">Assicurati che i due dispositivi si tocchino, quindi tocca il contenuto che vuoi inviare.</string>


### PR DESCRIPTION
…/settings.apk

#### Riga 3288 ####
Quell'opzione è presente nei dettagli selezionando una rete wi-fi, permette di segnare la rete wifi appunto come "Hotspot mobile", in modo che ne venga limitato/controllato l'utilizzo dei dati 
 Allego screenshot. 

![screenshot_2015-12-12-13-24-14_com android settings](https://cloud.githubusercontent.com/assets/16099943/11762005/49421f82-a0d7-11e5-8cb6-39597e6e007a.png)